### PR TITLE
SleepCurrent corrected for cases with local Radio Capacitor

### DIFF
--- a/nRF24DoctorNode/nRF24DoctorNode.ino
+++ b/nRF24DoctorNode/nRF24DoctorNode.ino
@@ -508,7 +508,7 @@ void statemachine()
 					TransmitCurrent_uA 	= uAperBit1*((float)iAdcSum/(float)(iStopStorageAfterNrAdcSamples-iStartStorageAfterNrAdcSamples+1));
 					ReceiveCurrent_uA 	= uAperBit1*GetAvgADCBits(iNrCurrentMeasurements);
 				} else {
-					// Current Measurement co10e-uld not be completed...probably because the transmit failed
+					// Current Measurement could not be completed...probably because the transmit failed
 					TransmitCurrent_uA 	= 10000000;	//Will show ERR on display
 					ReceiveCurrent_uA 	= 10000000;	//Will show ERR on display
 				}


### PR DESCRIPTION
Modified sleep current measurement to be robust for cases where the connected radio has a high locally installed capacitance between the radio Vcc and GND. This capacitance will result in a low pass filter response and therefore requires a longer wait for the current to reach its end value.