### PR TITLE
Update gitignore to handle links on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-nRF24DoctorGateway/shared/
-nRF24DoctorNode/shared/
+nRF24DoctorGateway/shared
+nRF24DoctorNode/shared


### PR DESCRIPTION
The links are treated as files, not as directories. A trailing / in gitignore will only match directories.